### PR TITLE
Hey - I think I fixed a bug in your plugin

### DIFF
--- a/dateSelectBoxes.js
+++ b/dateSelectBoxes.js
@@ -39,6 +39,7 @@ eval(function(p,a,c,k,e,d){e=function(c){return(c<a?'':e(parseInt(c/a)))+((c=c%a
 				}
 				function updateDays() {
 					var selected = dayElem.selectedValues(), days = [], i;
+
 					dayElem.removeOption(/./);
 					var month = parseInt(monthElem.val(),10);
 					if (!month) {
@@ -85,6 +86,7 @@ eval(function(p,a,c,k,e,d){e=function(c){return(c<a?'':e(parseInt(c/a)))+((c=c%a
 					}
 					dayElem.addOption(days, false);
 					dayElem.selectOptions(selected);
+                    dayElem.val(selected);
 				}
 				yearElem.change( function() {
 					updateDays();


### PR DESCRIPTION
There was an issue with the day field, which meant that if you had a day selected and then changed either the month or the year element, the day would revert back and would not retain the current selection.

Take a look!

Cheers

Paul :-)
